### PR TITLE
Amount to transfer always 0 after switching Pokémon.

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,7 +51,7 @@ var POKEMON_NAME = "Pidgey";
 $("#pokemon").on("change", function(e) {
     var elem = e.currentTarget;
     POKEMON_NAME = elem.options[elem.selectedIndex].text; 
-    CANDIES_TO_EVOLVE = elem.options[elem.selectedIndex].value;
+    CANDIES_TO_EVOLVE = +elem.options[elem.selectedIndex].value;
     $("#selected-pokemon").innerHTML = POKEMON_NAME;
 });
 


### PR DESCRIPTION
This PR solves a problem where the calculation gets messed up after switching Pokémon.
## Steps to reproduce
1. Enter 100 Pidgeys and 100 candy.
2. Check the results.
3. Switch to Weedle.
4. Switch back to Pidgey.
5. Check the results.
## Expected results

The results at step 2 and 5 should be identical: transfer 77 Pidgeys, then evolve 16 of them.
## Actual results

The results at step 5 are: transfer 0 Pidgeys, then evolve 9 of them.
## Proposed solution

This problem occurs because the `CANDIES_TO_EVOLVE` variable becomes a string when it is [set to the `value` of the selected option](https://github.com/paulirish/pidgey-grinding/blob/f641ff4721ede88dd16fb4a1acea19bfb8707a5b/app.js#L54). This breaks [the `shouldTransfer` check](https://github.com/paulirish/pidgey-grinding/blob/f641ff4721ede88dd16fb4a1acea19bfb8707a5b/app.js#L104), which now concatenates with `"1"` rather than adding 1. (Yay for type coercion! :stuck_out_tongue:)

This PR simply adds an explicit cast to a number.
